### PR TITLE
Remove nodes which no longer exist on the device

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -350,6 +350,12 @@ function onMessageArrived(message) {
           `${BASE_TOPIC}/${topic[0]}/${nodes[n]}/$properties`
         );
       }
+      // Remove old nodes from device object.
+      for (n in devices.deviceList[device_id].nodes) {
+        if (!nodes.includes(n)){
+          devices.$delete(devices.deviceList[device_id].nodes, n);
+        }
+      }
     } else if (topic[1] in devices.deviceList[device_id]["nodes"]) {
       // add attributes to node
       var node = topic[1];

--- a/js/app.js
+++ b/js/app.js
@@ -6,7 +6,7 @@
  */
 
 var deviceTopics = {};
-var deviceSubscribtions = {};
+var deviceSubscriptions = {};
 var colorPicker = VueColor.Compact;
 
 // MQTT client
@@ -55,8 +55,8 @@ var devices = new Vue({
     },
     wipeDevice: function(deviceId) {
       // unsubscribe from topics
-      for (var i = 0; i < deviceSubscribtions[deviceId].length; i++) {
-        client.unsubscribe(deviceSubscribtions[deviceId][i]);
+      for (var i = 0; i < deviceSubscriptions[deviceId].length; i++) {
+        client.unsubscribe(deviceSubscriptions[deviceId][i]);
       }
       // remove all retained messages from topics
       for (var i = 0; i < deviceTopics[deviceId].length; i++) {
@@ -69,7 +69,7 @@ var devices = new Vue({
       // remove device from objects
       delete this.deviceList[deviceId];
       delete deviceTopics[deviceId];
-      delete deviceSubscribtions[deviceId];
+      delete deviceSubscriptions[deviceId];
 
       // update view
       this.$forceUpdate();
@@ -249,21 +249,21 @@ function onConnectionLost(responseObject) {
 // subscribe to topic and keep that info
 function subscribe(deviceId, topic) {
   client.subscribe(topic, 1);
-  deviceSubscribtions[deviceId].push(topic);
+  deviceSubscriptions[deviceId].push(topic);
 }
 
 // Unsubscribe from all topics to which we have previously subscribed which start with the given
 // prefix.
 function unsubscribePrefix(deviceId, topicPrefix) {
   var remainingSubscripions = [];
-  for (topic of deviceSubscribtions[deviceId]) {
+  for (topic of deviceSubscriptions[deviceId]) {
     if (topic.startsWith(topicPrefix)) {
       client.unsubscribe(topic);
     } else {
       remainingSubscripions.push(topic);
     }
   }
-  deviceSubscribtions[deviceId] = remainingSubscripions;
+  deviceSubscriptions[deviceId] = remainingSubscripions;
 }
 
 // called when a message arrives
@@ -287,7 +287,7 @@ function onMessageArrived(message) {
 
     // add topic to deviceTopics
     deviceTopics[device_id] = [message.destinationName];
-    deviceSubscribtions[device_id] = [];
+    deviceSubscriptions[device_id] = [];
 
     devices.$set(devices.deviceList, device_id, {
       id: device_id,

--- a/js/app.js
+++ b/js/app.js
@@ -252,6 +252,20 @@ function subscribe(deviceId, topic) {
   deviceSubscribtions[deviceId].push(topic);
 }
 
+// Unsubscribe from all topics to which we have previously subscribed which start with the given
+// prefix.
+function unsubscribePrefix(deviceId, topicPrefix) {
+  var remainingSubscripions = [];
+  for (topic of deviceSubscribtions[deviceId]) {
+    if (topic.startsWith(topicPrefix)) {
+      client.unsubscribe(topic);
+    } else {
+      remainingSubscripions.push(topic);
+    }
+  }
+  deviceSubscribtions[deviceId] = remainingSubscripions;
+}
+
 // called when a message arrives
 function onMessageArrived(message) {
   // console.log("onMessageArrived: " + message.topic + " Payload: " + message.payloadString);
@@ -354,6 +368,7 @@ function onMessageArrived(message) {
       for (n in devices.deviceList[device_id].nodes) {
         if (!nodes.includes(n)){
           devices.$delete(devices.deviceList[device_id].nodes, n);
+          unsubscribePrefix(device_id, `${BASE_TOPIC}/${topic[0]}/${nodes[n]}/`);
         }
       }
     } else if (topic[1] in devices.deviceList[device_id]["nodes"]) {

--- a/js/app.js
+++ b/js/app.js
@@ -332,6 +332,10 @@ function onMessageArrived(message) {
       // add nodes to device object
       var nodes = payload.split(",");
       for (n in nodes) {
+        // Don't add the node if it's already there, to avoid unnecessary UI updates.
+        if (nodes[n] in devices.deviceList[device_id].nodes) {
+          continue;
+        }
         // devices.$set(devices.deviceList.nodes, node, {});
         devices.$set(devices.deviceList[device_id].nodes, nodes[n], {
           id: nodes[n],

--- a/js/app_slim.js
+++ b/js/app_slim.js
@@ -260,6 +260,20 @@ function subscribe(deviceId, topic) {
   deviceSubscribtions[deviceId].push(topic);
 }
 
+// Unsubscribe from all topics to which we have previously subscribed which start with the given
+// prefix.
+function unsubscribePrefix(deviceId, topicPrefix) {
+  var remainingSubscripions = [];
+  for (topic of deviceSubscribtions[deviceId]) {
+    if (topic.startsWith(topicPrefix)) {
+      client.unsubscribe(topic);
+    } else {
+      remainingSubscripions.push(topic);
+    }
+  }
+  deviceSubscribtions[deviceId] = remainingSubscripions;
+}
+
 // called when a message arrives
 function onMessageArrived(message) {
   // console.log("onMessageArrived: " + message.topic + " Payload: " + message.payloadString);
@@ -361,6 +375,7 @@ function onMessageArrived(message) {
       for (n in devices.deviceList[device_id].nodes) {
         if (!nodes.includes(n)){
           devices.$delete(devices.deviceList[device_id].nodes, n);
+          unsubscribePrefix(device_id, `${BASE_TOPIC}/${topic[0]}/${nodes[n]}/`);
         }
       }
     } else if (topic[1] in devices.deviceList[device_id]["nodes"]) {

--- a/js/app_slim.js
+++ b/js/app_slim.js
@@ -6,7 +6,7 @@
  */
 
 var deviceTopics = {};
-var deviceSubscribtions = {};
+var deviceSubscriptions = {};
 var colorPicker = VueColor.Compact;
 
 // MQTT client
@@ -55,8 +55,8 @@ var devices = new Vue({
     },
     wipeDevice: function(deviceId) {
       // unsubscribe from topics
-      for (var i = 0; i < deviceSubscribtions[deviceId].length; i++) {
-        client.unsubscribe(deviceSubscribtions[deviceId][i]);
+      for (var i = 0; i < deviceSubscriptions[deviceId].length; i++) {
+        client.unsubscribe(deviceSubscriptions[deviceId][i]);
       }
       // remove all retained messages from topics
       for (var i = 0; i < deviceTopics[deviceId].length; i++) {
@@ -69,7 +69,7 @@ var devices = new Vue({
       // remove device from objects
       delete this.deviceList[deviceId];
       delete deviceTopics[deviceId];
-      delete deviceSubscribtions[deviceId];
+      delete deviceSubscriptions[deviceId];
 
       // update view
       this.$forceUpdate();
@@ -257,21 +257,21 @@ function onConnectionLost(responseObject) {
 // subscribe to topic and keep that info
 function subscribe(deviceId, topic) {
   client.subscribe(topic, 1);
-  deviceSubscribtions[deviceId].push(topic);
+  deviceSubscriptions[deviceId].push(topic);
 }
 
 // Unsubscribe from all topics to which we have previously subscribed which start with the given
 // prefix.
 function unsubscribePrefix(deviceId, topicPrefix) {
   var remainingSubscripions = [];
-  for (topic of deviceSubscribtions[deviceId]) {
+  for (topic of deviceSubscriptions[deviceId]) {
     if (topic.startsWith(topicPrefix)) {
       client.unsubscribe(topic);
     } else {
       remainingSubscripions.push(topic);
     }
   }
-  deviceSubscribtions[deviceId] = remainingSubscripions;
+  deviceSubscriptions[deviceId] = remainingSubscripions;
 }
 
 // called when a message arrives
@@ -295,7 +295,7 @@ function onMessageArrived(message) {
 
     // add topic to deviceTopics
     deviceTopics[device_id] = [message.destinationName];
-    deviceSubscribtions[device_id] = [];
+    deviceSubscriptions[device_id] = [];
 
     devices.$set(devices.deviceList, device_id, {
       id: device_id,

--- a/js/app_slim.js
+++ b/js/app_slim.js
@@ -357,6 +357,12 @@ function onMessageArrived(message) {
           `${BASE_TOPIC}/${topic[0]}/${nodes[n]}/$properties`
         );
       }
+      // Remove old nodes from device object.
+      for (n in devices.deviceList[device_id].nodes) {
+        if (!nodes.includes(n)){
+          devices.$delete(devices.deviceList[device_id].nodes, n);
+        }
+      }
     } else if (topic[1] in devices.deviceList[device_id]["nodes"]) {
       // add attributes to node
       var node = topic[1];

--- a/js/app_slim.js
+++ b/js/app_slim.js
@@ -339,6 +339,10 @@ function onMessageArrived(message) {
       // add nodes to device object
       var nodes = payload.split(",");
       for (n in nodes) {
+        // Don't add the node if it's already there, to avoid unnecessary UI updates.
+        if (nodes[n] in devices.deviceList[device_id].nodes) {
+          continue;
+        }
         // devices.$set(devices.deviceList.nodes, node, {});
         devices.$set(devices.deviceList[device_id].nodes, nodes[n], {
           id: nodes[n],


### PR DESCRIPTION
Previously if the `$nodes` of a device was updated to no longer include a node, the UI would incorrectly continue to display it.