### PR TITLE
Add signal and name default

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,12 @@
                       </span>
                     </b-list-group-item>
                     <b-list-group-item>
+                      Signal:
+                      <span class="float-right">
+                        {{ device.stats_signal }}
+                      </span>
+                    </b-list-group-item>
+                    <b-list-group-item>
                       Stats interval:
                       <span class="float-right">
                         {{ device.stats_interval }} seconds

--- a/js/app.js
+++ b/js/app.js
@@ -387,7 +387,7 @@ function onMessageArrived(message) {
             properties[p],
             {
               id: properties[p],
-              name: "",
+              name: properties[p],
               settable: "false",
               datatype: "string",
               format: "",

--- a/js/app.js
+++ b/js/app.js
@@ -301,6 +301,7 @@ function onMessageArrived(message) {
       stats_interval: "",
       stats_uptime: "",
       stats_freeheap: "",
+      stats_signal: "",
       implementation: "",
       nodes: {},
       topic: `${BASE_TOPIC}/${topic[0]}`,
@@ -341,6 +342,8 @@ function onMessageArrived(message) {
         devices.deviceList[device_id]["stats_interval"] = payload;
       } else if (topic[2] === "freeheap") {
         devices.deviceList[device_id]["stats_freeheap"] = payload;
+      } else if (topic[2] === "signal") {
+        devices.deviceList[device_id]["stats_signal"] = payload;
       }
     } else if (topic[1] === "$nodes") {
       // add nodes to device object


### PR DESCRIPTION
Added signal to $stats and set the default name for properties.
Default property name, it's quite useful if optional topic `$name` is not set (as in my case).

note: I'm sorry but I have closed the previous #8, I have tried to do a rebase->squash->push->force...but I have make a mess